### PR TITLE
add square of energy term in Qx

### DIFF
--- a/Appendices/App_HorizontalDamping.tex
+++ b/Appendices/App_HorizontalDamping.tex
@@ -28,7 +28,7 @@ We must evaluate $\delta E$ along the off-energy orbit. Since $\delta E = P_\gam
 \label{eq:energy_off}
 \end{equation}
 
-Notice that since $x = x_\beta + x_\delta$, when \eqref{eq:energy_off} is inserted into \eqref{eq:amp} the terms $x_\delta x_\beta$ and $x_\delta x_\beta'$
+Notice that since $x = x_\beta + x_\epsilon$, when \eqref{eq:energy_off} is inserted into \eqref{eq:amp} the terms $x_\epsilon x_\beta$ and $x_\epsilon x_\beta'$
 will be zero when averaged over betatron oscilations, then we can write down $(1 + x/\rho_s) = (1 + x_\beta / \rho_s)$. Then we obtain
 
 \[

--- a/Chapter_5/5_03_DistributionFluctuations.tex
+++ b/Chapter_5/5_03_DistributionFluctuations.tex
@@ -58,7 +58,7 @@ The distribution of energy oscillations of the electrons in a stored bunch can n
 \end{align}
 The projection on the horizontal axis is
 \begin{align}
-	\int_{-\infty}^{\infty} \Psi(\epsilon,\theta) d\theta = \dfrac{N}{\sqrt{2\pi} \sigma\epsilon} \exp\left( -\dfrac{\epsilon^2}{2\sigma_\epsilon^2} \right) d\epsilon,
+	\int_{-\infty}^{\infty} \Psi(\epsilon,\theta) d\theta = \dfrac{N}{\sqrt{2\pi} \sigma_\epsilon} \exp\left( -\dfrac{\epsilon^2}{2\sigma_\epsilon^2} \right) d\epsilon,
 \end{align}
 which agrees with the $w(\epsilon)$ of Eq.~\eqref{eq:5.50}. Similarly, the distribution in $\theta$ is
 \begin{align}

--- a/Chapter_5/5_05_BeamWidth.tex
+++ b/Chapter_5/5_05_BeamWidth.tex
@@ -86,7 +86,7 @@ Since the azimuth $s_1$ may be anywhere, we may now drop the subscript. Combinin
 The form of the result is similar to that obtained for $\sigma_\epsilon$. Both $\tau_x$ and $Q_x$, are numbers which are determined from the overall properties of the guide field -- and do not, therefore, vary with $s$. The only variation of $\sigma_{x_\beta}$ comes from the factor $\beta(s)$. This then is our result for the horizontal spread of a stored electron beam due to quantum induced betatron oscillations.\\
 To see the physical significance of our result we must recover the complexities hidden in $\tau_x$ and $Q_x$. Taking $\mathscr{N}\mean{u^2}$ from Eq.~\eqref{eq:5.41}
 \begin{align}
-	Q_x = \dfrac{3}{2} C_u \hslash c \gamma_0^3 \dfrac{\mean{P_\gamma}_s \mean{|G|^3\mathscr{H}}_s}{\mean{G^2}},
+	Q_x = \dfrac{3}{2} C_u \hslash c \gamma_0^3 \dfrac{\mean{P_\gamma}_s \mean{|G|^3\mathscr{H}}_s}{E_0^2 \mean{G^2}},
 \end{align}
 where $G(s)$ is the inverse radius of the orbit, and, $\mathscr{H}(s)$ is the function of Eq.~\eqref{eq:5.71}. Taking $\tau_x$ from Eq.~\eqref{eq:4.53} we get that
 \begin{align}


### PR DESCRIPTION
I found an error in equation 5.83 when opening equation 5.78: the square of the nominal energy was missing in the denominator. I would like you to review it.